### PR TITLE
DM-27113: Ignore fgcmLookUpTable (for now).

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -246,6 +246,7 @@ def makeTask(butler: Butler, *, continue_: bool = False, reruns: List[Rerun]):
                                          "ref_cat", "raw"]
     config.datasetIgnorePatterns.append("*_camera")
     config.datasetIgnorePatterns.append("yBackground")
+    config.datasetIgnorePatterns.append("fgcmLookUpTable")
     config.fileIgnorePatterns.extend(["*.log", "*.png", "rerun*"])
     config.doRegisterInstrument = not continue_
     config.doWriteCuratedCalibrations = not continue_


### PR DESCRIPTION
Ingesting these properly should involve changes to obs_subaru, and
(unlike yBackground) converting them as calibrations when they appear
outside the root directory.