### PR TITLE
DM-28246: Configure conversion of latest Gaia DR2 reference catalog.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -283,6 +283,9 @@ def makeTask(butler: Butler, *, continue_: bool = False, reruns: List[Rerun]):
         # repos (default is all datasets).
         config.datasetIncludePatterns = ["brightObjectMask", "flat", "bias", "dark", "fringe", "sky",
                                          "ref_cat", "raw"]
+    gaiaRefCat = "gaia_dr2_20200414"
+    if gaiaRefCat not in config.refcats:
+        config.refCats.append(gaiaRefCat)
     config.datasetIgnorePatterns.append("*_camera")
     config.datasetIgnorePatterns.append("yBackground")
     config.datasetIgnorePatterns.append("fgcmLookUpTable")


### PR DESCRIPTION
This is not in the obs_subaru configs because it would cause ci_hsc to fail (since that doesn't have a Gaia refcat in its testdata).  But it may be better to eventually move this override to obs_subaru and instead revert it in ci_hsc configs.